### PR TITLE
Remove Tox

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,6 +14,5 @@ pytest-xdist==1.15
 pytest==3.0.2
 requests==2.11.1
 six==1.10.0
-tox==2.3.1
 wcwidth==0.1.7
 wheel==0.29.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,0 @@
-[tox]
-envlist = py35
-skipsdist = True
-
-[testenv]
-deps=
-  -r{toxinidir}/requirements/dev.txt
-commands=py.test --cov karspexet


### PR DESCRIPTION
**Remove Tox**
Tox is certainly a handy tool, but it's overkill for what we are
doing. We don't need to run our tests on multiple different python
platforms.

We have no need for another layer of abstraction. This is just one
app. We can safely rely on py.test and be happy with that.

That also means we can use things like `dj-database-url` to
automatically pick up a DATABASE_URL environment variable when running
tests on CI, and not having to mess around with special configs for
that (Tox seems to hide all env vars and run everything in a vacuum).

