### PR TITLE
Add dj-database-url for parsing db settings

### DIFF
--- a/karspexet/settings.py
+++ b/karspexet/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
 import os
+import dj_database_url
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -75,18 +76,8 @@ WSGI_APPLICATION = 'karspexet.wsgi.application'
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'karspexet',
-        'USER': 'django',
-        'PASSWORD': '',
-        'HOST': '', # Connect thorugh UNIX socket
-        'TEST': {
-            'NAME': 'karspexet-test',
-        },
-    }
+    'default': dj_database_url.config(default='postgres://127.0.0.1/karspexet'),
 }
-
 
 # Password validation
 # https://docs.djangoproject.com/en/1.9/ref/settings/#auth-password-validators

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,3 @@
 django==1.10.1
 psycopg2==2.6.2
+dj-database-url==0.4.1


### PR DESCRIPTION
This is one step towards having a [12-factor app](https://12factor.net).

Demanding that all developers have the same database config is tedious.

An app should be easy to get started with, and having a simple database
config is one part of that.

This should also let us use a DATABASE_URL configuration string both on
CI and when deploying to production.