### PR TITLE
Remove hound CI config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,0 @@
-python:
-  enabled: true


### PR DESCRIPTION
**Remove hound CI config**
We are not using it, and CodeClimate provides pretty much the same
features.

