### PR TITLE
Configure coverage to run properly locally

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+source = .
+omit =
+  manage.py


### PR DESCRIPTION
This makes `py.test --cov --cov-report=html:htmlcov` not include my entire
virtualenv in the report.

I also omit `manage.py` since it's autogenerated and will probably never change.