### PR TITLE
Add .codacy.yml configuration file

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,15 @@
+---
+engines:
+  pylint:
+    enabled: true
+    python_version: 3
+    exclude_paths:
+      - tests/
+      - karspexet/**/migrations/**/*
+      - karspexet/**/test_*.py
+  bandit:
+    enabled: true
+    exclude_paths:
+      - tests/
+      - karspexet/**/migrations/**/*
+      - karspexet/**/test_*.py


### PR DESCRIPTION
This file can be used to configure some extra stuff for Codacy, like exclude
paths that it should not care about (our tests don't need security checks, for
instance).