### PR TITLE
Replace Main h1 tag using webfonts with an svg image

### DIFF
--- a/karspexet/templates/base.html
+++ b/karspexet/templates/base.html
@@ -1,4 +1,4 @@
-{% load menu_tags cms_tags sekizai_tags staticfiles %}
+{% load menu_tags cms_tags sekizai_tags staticfiles svg %}
 <html>
     <head>
         <title>{% page_attribute "page_title" %}</title>
@@ -12,7 +12,7 @@
         {% cms_toolbar %}
         <div id="navbar">
             <div class="horizontal titleContainer">
-              <h1><span class="g">KÅR</span>S<span class="g">P</span>EX<span class="g">ET</span></h1>
+              {% svg 'karspexet-logo-pergament' %}
             </div>
 
             <div class="horizontal menuContainer">

--- a/static/svg/karspexet-logo-pergament.svg
+++ b/static/svg/karspexet-logo-pergament.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 76.729164 13.229167"
+   height="50"
+   width="290">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient4483">
+      <stop
+         id="stop4479"
+         offset="0"
+         style="stop-color:#ff9900;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffcc00;stop-opacity:1"
+         offset="0.24999952"
+         id="stop4489" />
+      <stop
+         id="stop4493"
+         offset="0.5"
+         style="stop-color:#ffffaa;stop-opacity:1" />
+      <stop
+         id="stop4491"
+         offset="0.75000048"
+         style="stop-color:#ffcc00;stop-opacity:1" />
+      <stop
+         id="stop4481"
+         offset="1"
+         style="stop-color:#ff9900;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-1.6687624,1.7028278)"
+       gradientUnits="userSpaceOnUse"
+       y2="294.35416"
+       x2="42.333332"
+       y1="283.77084"
+       x1="42.333332"
+       id="linearGradient4485"
+       xlink:href="#linearGradient4483" />
+  </defs>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-283.77083)"
+     id="layer1">
+    <text
+       id="text4269"
+       y="52.45863"
+       x="27.635035"
+       style="font-style:normal;font-weight:normal;font-size:10.58333302px;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="opacity:0.93000034;fill:#000000;fill-opacity:1;stroke-width:0.26458332"
+         y="61.822399"
+         x="27.635035"
+         id="tspan4267" /></text>
+    <text
+       id="text4294"
+       y="294.57773"
+       x="0.84525275"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.49329567px;font-family:Pergament;-inkscape-font-specification:'Pergament, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient4485);fill-opacity:1;stroke:none;stroke-width:0.31233239"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.49329567px;font-family:Pergament;-inkscape-font-specification:'Pergament, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient4485);fill-opacity:1;stroke-width:0.31233239"
+         y="294.57773"
+         x="0.84525275"
+         id="tspan4292">KÅRSPEXET</tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
This will lower the amount of assets loaded when loading the page, since we
don't have to load the Pergament webfont anymore.

The SVG can also be inlined when rendering the HTML server-side to increase
loading speed even more, since that would remove the need for an additional
roundtrip to the server for fetching the image.