### PR TITLE
Fix links in economy overview

### DIFF
--- a/karspexet/ticket/templates/economy/overview.html
+++ b/karspexet/ticket/templates/economy/overview.html
@@ -18,7 +18,7 @@
   <tbody>
     {% for show in shows %}
     <tr>
-      <td><a href="{% url 'economy_show' show.id %}">{{ show.production_name }}</a></td>
+      <td><a href="{% url 'economy_show_detail' show.id %}">{{ show.production_name }}</a></td>
       <td>{{ show.date|date:"Y-m-d H:i"  }}</td>
       <td>{{ show.venue_name}}</td>
       <td class="number">{{ show.ticket_count }}</td>


### PR DESCRIPTION
The URL is called `economy_show_detail`, so let's use that so that the page
stops crashing and the links start working.