### PR TITLE
Fix HTML validation varnings

### DIFF
--- a/karspexet/templates/base.html
+++ b/karspexet/templates/base.html
@@ -4,7 +4,7 @@
 <html lang="sv">
   <head>
     <meta charset="utf-8">
-    <title>{% page_attribute "page_title" %}</title>
+    <title>{% block title %}{% page_attribute "page_title" %}{% endblock %}</title>
     <meta name="description" content="{% page_attribute 'meta_description' %}" />
     <link rel="shortcut icon" href="{% static 'favicon.ico' %}">
     <script src="https://js.stripe.com/v3/" async></script>

--- a/karspexet/templates/base.html
+++ b/karspexet/templates/base.html
@@ -3,9 +3,10 @@
 <html>
   <head>
     <title>{% page_attribute "page_title" %}</title>
+    <meta name="description" content="{% page_attribute 'meta_description' %}" />
     <link rel="shortcut icon" href="{% static 'favicon.ico' %}">
     <script src="https://js.stripe.com/v3/" async></script>
-    <meta type="description" content="Kårspexet är en studentförening på KTH som sätter upp interaktiv humoristisk musikal med historisk anknytning, ett så kallat spex, varje år. Vi är 70 ideellt arbetande amatörer som brinner för att skapa en proffsig produkt med ingenjörsmässiga metoder. Kom gärna förbi och se oss när vi spelar på Södra Teatern!" />
+
     {% render_bundle "app" "js" attrs="async" %}
     {% render_bundle "style" "css" attrs="async" %}
     {% render_block "js" %}

--- a/karspexet/templates/base.html
+++ b/karspexet/templates/base.html
@@ -6,6 +6,7 @@
     <meta charset="utf-8">
     <title>{% block title %}{% page_attribute "page_title" %}{% endblock %}</title>
     <meta name="description" content="{% page_attribute 'meta_description' %}" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="{% static 'favicon.ico' %}">
     <script src="https://js.stripe.com/v3/" async></script>
 

--- a/karspexet/templates/base.html
+++ b/karspexet/templates/base.html
@@ -26,7 +26,7 @@
     {% endblock content %}
     <div class="footer">
       <div class="relatedLinks">
-        <a href="http://ths.kth.se/"><img class="thsLogo footerElement" src="{% static 'ths_logo.png' %}" /></a>
+        <a href="http://ths.kth.se/"><img class="thsLogo footerElement" src="{% static 'ths_logo.png' %}" alt="THS Logotyp"/></a>
       </div>
       <div class="socialMedia footerElement">
         <span class="secondary-menu">

--- a/karspexet/templates/base.html
+++ b/karspexet/templates/base.html
@@ -1,6 +1,7 @@
 {% load menu_tags cms_tags sekizai_tags staticfiles svg %}
 {% load render_bundle from webpack_loader %}
-<html>
+<!doctype html>
+<html lang="sv">
   <head>
     <title>{% page_attribute "page_title" %}</title>
     <meta name="description" content="{% page_attribute 'meta_description' %}" />

--- a/karspexet/templates/base.html
+++ b/karspexet/templates/base.html
@@ -3,6 +3,7 @@
 <!doctype html>
 <html lang="sv">
   <head>
+    <meta charset="utf-8">
     <title>{% page_attribute "page_title" %}</title>
     <meta name="description" content="{% page_attribute 'meta_description' %}" />
     <link rel="shortcut icon" href="{% static 'favicon.ico' %}">

--- a/karspexet/templates/menu.html
+++ b/karspexet/templates/menu.html
@@ -9,7 +9,7 @@
         {% if forloop.counter == forloop.revcounter|add:"-1" %}
     <li>
       <a href="/">
-        <img class="luva" src="{% static 'svg/luva-inkscape.svg' %}">
+        <img class="luva" src="{% static 'svg/luva-inkscape.svg' %}" alt="">
       </a>
     </li>
         {% else %}

--- a/karspexet/templates/ticket/select_seats.html
+++ b/karspexet/templates/ticket/select_seats.html
@@ -1,5 +1,8 @@
 {% extends "ticket/base.html" %}
 {% load staticfiles %}
+{% block title %}
+  Köp biljett - Kårspexet
+{% endblock %}
 {% block ticket_content %}
     <div>
     <h2>Köp biljetter för {{ show }}</h2>


### PR DESCRIPTION
Fixar några varningar från https://validator.w3.org/nu/?doc=https%3A%2F%2Fkarspexet.se%2F

Ser också till att meta-description är redigerbar från django-cms, och att vi lägger till lite andra rekommenderade element till `<head>`.

Går att reviewa commit för commit.