### PR TITLE
Display production description in seat selection

### DIFF
--- a/karspexet/templates/ticket/select_seats.html
+++ b/karspexet/templates/ticket/select_seats.html
@@ -7,6 +7,10 @@
     <div>
     <h2>Köp biljetter för {{ show }}</h2>
 
+    {% if show.production.description %}
+    <p>{{ show.production.description }}</p>
+    {% endif %}
+
     <h3>Instruktioner</h3>
 
     <ol>


### PR DESCRIPTION
This means we can display some more information about the show and any
notes and/or warnings related to the performance.