### PR TITLE
Fix crash during payment when no email address is provided

### DIFF
--- a/karspexet/ticket/forms.py
+++ b/karspexet/ticket/forms.py
@@ -1,0 +1,4 @@
+from django import forms
+
+class CustomerEmailForm(forms.Form):
+    email = forms.EmailField(required=True, label="E-postadress")

--- a/karspexet/ticket/models.py
+++ b/karspexet/ticket/models.py
@@ -8,6 +8,7 @@ from django.db.models import Q
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
 from django.utils.crypto import get_random_string
+from django.urls import reverse
 from datetime import date
 
 from karspexet.show.models import Show
@@ -84,6 +85,9 @@ class Reservation(models.Model):
             self.total = self.ticket_price - self.discount.amount
         except ObjectDoesNotExist:
             self.total = self.ticket_price
+
+    def get_absolute_url(self):
+        return reverse('reservation_detail', kwargs={'reservation_code': self.reservation_code})
 
 
 class Account(models.Model):

--- a/karspexet/ticket/payment.py
+++ b/karspexet/ticket/payment.py
@@ -116,6 +116,8 @@ class PaymentProcess:
         return self.reservation
 
     def _send_mail_to_customer(self):
+        if not self.account.email:
+            return
         subject = "Dina biljetter till Kårspexet"
         tickets_string = []
         for seat in self.reservation.seats():

--- a/karspexet/ticket/tasks.py
+++ b/karspexet/ticket/tasks.py
@@ -1,0 +1,43 @@
+import logging
+from django.conf import settings
+from django.core.mail import send_mail
+from django.contrib.sites.models import Site
+from django.template.loader import render_to_string
+from django.template import Context
+
+logger = logging.getLogger(__file__)
+
+
+def send_ticket_email_to_customer(reservation, email, name=None):
+    '''Send an email to the customer with a link to their tickets
+
+    If the supplied email is empty, this will silently fail. The reason for this is that this is used in the payment
+    flow, and if we raise an error here, it will crash the payment transaction, and at that point we have likely
+    charged someone's card without giving them tickets.
+
+    Therefore the trade-off is made that if the customer fails to provide a valid email address, they will not receive
+    an email. They will however, have another chance to send the reservation information via email at the
+    reservation-detail page.
+    '''
+    if not email:
+        return
+
+    if not name:
+        name = email
+
+    to_address = f'{name} <{email}>'
+    subject = 'Dina biljetter till Kårspexet'
+    site = Site.objects.get_current()
+    reservation_url = f'https://{site.domain}{reservation.get_absolute_url()}'
+    body = render_to_string('reservation_email.txt', Context({
+        'reservation': reservation,
+        'url': reservation_url,
+    }))
+
+    send_mail(
+        subject,
+        body,
+        settings.TICKET_EMAIL_FROM_ADDRESS,
+        [to_address],
+        fail_silently=False,
+    )

--- a/karspexet/ticket/templates/reservation_detail.html
+++ b/karspexet/ticket/templates/reservation_detail.html
@@ -46,6 +46,13 @@
       </li>
       {% endfor %}
     </ul>
+
+    <h3>Skicka bokningen via E-post</h3>
+    <form action="{% url 'send_reservation_email' reservation.reservation_code %}" method="post">
+      {% csrf_token %}
+      {{ email_form.as_p }}
+      <input type="submit" value="Skicka via E-post!">
+    </form>
   </main>
 </div>
 {% endblock %}

--- a/karspexet/ticket/templates/reservation_email.txt
+++ b/karspexet/ticket/templates/reservation_email.txt
@@ -1,0 +1,11 @@
+Här är dina biljetter till Kårspexets föreställning: {{ reservation.show }}
+
+Bokningskod: {{ reservation.reservation_code }}
+
+{% for seat in reservation.seats %}
+* {{ seat.group.name }}: {{ seat.name }}
+{% endfor %}
+
+Länk till din reservation: {{ url }}
+
+Välkommen!

--- a/karspexet/ticket/urls.py
+++ b/karspexet/ticket/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     url(r"^reservation/(?P<reservation_code>[A-Z0-9]+)/?$", views.reservation_detail, name="reservation_detail"),
     url(r"^ticket/(?P<reservation_id>\d+)-(?P<ticket_code>[A-Z0-9]+)/?$", views.ticket_detail, name="ticket_detail"),
     url(r"^ticket/(?P<reservation_id>\d+)-(?P<ticket_code>[A-Z0-9]+).pdf$", views.ticket_pdf, name="ticket_pdf"),
+    url(r"^reservation/(?P<reservation_code>[A-Z0-9]+)/send_reservation_email$", views.send_reservation_email, name="send_reservation_email"),
     url(r"^cancel/(?P<show_id>\d+)/?$", views.cancel_reservation, name="cancel_reservation"),
     url(r"^$", views.home, name="ticket_home"),
 ]

--- a/karspexet/ticket/views.py
+++ b/karspexet/ticket/views.py
@@ -13,14 +13,17 @@ from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
-from django.shortcuts import redirect, render
+from django.shortcuts import redirect, render, get_object_or_404
 from django.template.response import HttpResponse, TemplateResponse
 from django.utils import timezone
+from django.views.decorators.http import require_POST
 
 from karspexet.show.models import Show
 from karspexet.ticket.models import Reservation, PricingModel, InvalidVoucherException, AlreadyDiscountedException, Voucher
 from karspexet.ticket.payment import PaymentError, PaymentProcess
 from karspexet.venue.models import Seat
+from karspexet.ticket.forms import CustomerEmailForm
+from karspexet.ticket.tasks import send_ticket_email_to_customer
 
 if settings.PAYMENT_PROCESS == "stripe":
     stripe_keys = settings.ENV["stripe"]
@@ -154,6 +157,7 @@ def process_payment(request, reservation_id):
 
 def reservation_detail(request, reservation_code):
     reservation = Reservation.objects.get(reservation_code=reservation_code)
+    email_form = CustomerEmailForm()
 
     return TemplateResponse(request, "reservation_detail.html", {
         'reservation': reservation,
@@ -161,6 +165,7 @@ def reservation_detail(request, reservation_code):
         'venue': reservation.show.venue,
         'production': reservation.show.production,
         'tickets': reservation.ticket_set(),
+        'email_form': email_form,
     })
 
 
@@ -224,6 +229,19 @@ def cancel_reservation(request, show_id):
     if reservation_id:
         Reservation.objects.filter(pk=reservation_id).delete()
     return redirect("ticket_home")
+
+
+@require_POST
+def send_reservation_email(request, reservation_code):
+    reservation = get_object_or_404(Reservation, reservation_code=reservation_code)
+    form = CustomerEmailForm(data=request.POST)
+    if form.is_valid():
+        send_ticket_email_to_customer(reservation, form.data['email'])
+        messages.success(request, 'E-postmeddelande skickat!')
+    else:
+        messages.error(request, 'Felaktig e-postadress')
+
+    return redirect("reservation_detail", reservation_code=reservation.reservation_code)
 
 
 def _session_expired(request):


### PR DESCRIPTION
This is a partial solution to #72 and would provide a workaround for #78. It would still crash on invalid email addresses or if the email-sending failed for some other reason.

I want to also address those issues but I would prefer to do so in a separate PR.