### PR TITLE
Add a slight boxshadow to the select show cards

### DIFF
--- a/assets/css/karspexet.css
+++ b/assets/css/karspexet.css
@@ -144,13 +144,17 @@ a {
   border-radius: 5px;
 }
 
-.card_container{
+.card_container {
   display: flex;
   flex: 1 0 auto;
   flex-shrink: 0;
   flex-flow: row wrap;
   justify-content: space-around;
   align-items: flex-start;
+}
+
+.card_container.select_show {
+  flex: 0 0 auto;
 }
 
 .card {
@@ -201,9 +205,13 @@ a {
   text-decoration: none;
 }
 
-.show-card {
-  /* box-shadow: 0 2px 10px #fd0; */
+.show_card {
   border-radius: 10px;
+}
+
+.select_show .show-card {
+  box-shadow: 0 0 6px 1px rgba(255, 221, 0, 0.5);
+  margin-top: 2em;
 }
 
 .show-card:hover {
@@ -299,6 +307,7 @@ a {
   flex-direction: row;
   font-size: 14px;
   margin: auto;
+  margin-bottom: 0;
   height: 80px;
   width: 100%;
   background-color: rgb(141, 4, 28);

--- a/karspexet/templates/ticket/ticket.html
+++ b/karspexet/templates/ticket/ticket.html
@@ -10,7 +10,7 @@
     <p>{% placeholder "eller-titel" %}</p>
   </div>
 </div>
-<div class="card_container">
+<div class="card_container select_show">
   {% for show in upcoming_shows %}
   <a class="show-card" href="{% url "select_seats" show.slug %}">
     <article class="card">


### PR DESCRIPTION
This makes them stand out a bit more on the page.

Those cards would now look like this:

![2019-02-09-130135_485x344_scrot](https://user-images.githubusercontent.com/2308/52520572-ddbfc980-2c6a-11e9-9f9b-9d9cb4fb0ef1.png)

This also fixes an issue where on really high resolution displays (e.g. 4k), if the number of available shows were plentiful enough to wrap to a second row, there would be a really large empty space between the two rows.

Before this change it looks like this:

![2019-02-09-130702_688x820_scrot](https://user-images.githubusercontent.com/2308/52520624-b7e6f480-2c6b-11e9-8c25-f7b03d7cb29c.png)


This fix will keep the distance between the two rows of cards on a decent level, while still keeping the footer at the bottom of the page.  
