### PR TITLE
Remove curtsies and greenlet

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,8 +4,6 @@ blessings==1.6
 bpython==0.15
 codeclimate-test-reporter==0.1.2
 codacy-coverage==1.3.6
-curtsies==0.2.9
-greenlet==0.4.10
 isort
 jedi==0.9.0
 py==1.4.34


### PR DESCRIPTION
These are dependencies of bpython and we don't need to depend on them
directly.