### PR TITLE
Update psycopg2 to psycopg2-binary

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 django==1.10.8
-psycopg2==2.6.2
+psycopg2-binary==2.7.7
 dj-database-url==0.4.1
 python-dateutil==2.6.0
 stripe==1.53.0


### PR DESCRIPTION
Also update it to a version that can build with support for PostgreSQL
11.1 on Python 3.7.2.