### PR TITLE
Remove transient dependencies

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,8 +1,6 @@
 -r base.txt
 
-blessings==1.6
 bpython==0.17.1
-codeclimate-test-reporter==0.1.2
 codacy-coverage==1.3.6
 isort
 jedi==0.9.0
@@ -12,8 +10,4 @@ pytest-cov==2.5.1
 pytest-django==3.1.2
 pytest-xdist==1.18.2
 pytest==3.1.3
-requests==2.21.0
-six==1.10.0
-wcwidth==0.1.7
-wheel==0.29.0
 factory_boy==2.8.1


### PR DESCRIPTION
These dependencies are transient dependencies of some other dependency,
so we don't need to depend on them explicitly.

* We don't use CodeClimate anymore so `codeclimate-test-reporter` is not
  needed at all
* `blessings` and `wcwidth` are dependencies of `curtsies`, which is something `bpython`
  depends on
* `requests` comes from `stripe`
* `six` is a dependency of a whole bunch of other packages
* `wheel` should not be in the dependencies list at all