### PR TITLE
Remove dependency versions for testing packages

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,6 +6,5 @@ isort
 jedi==0.13.2
 pytest-cov
 pytest-django
-pytest-xdist
 pytest
 factory_boy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,8 +4,8 @@ bpython==0.17.1
 codacy-coverage==1.3.6
 isort
 jedi==0.13.2
-pytest-cov==2.5.1
-pytest-django==3.1.2
-pytest-xdist==1.18.2
-pytest==3.1.3
-factory_boy==2.8.1
+pytest-cov
+pytest-django
+pytest-xdist
+pytest
+factory_boy


### PR DESCRIPTION
I don't think we necessarily need to freeze the versions of these
packages. If there's ever a problem with having dev/test packages
frozen, we can lock those particular packages down at that point.