### PR TITLE
Remove more excess top-level dependencies

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,8 +4,6 @@ bpython==0.17.1
 codacy-coverage==1.3.6
 isort
 jedi==0.13.2
-py==1.4.34
-pygments==2.3.1
 pytest-cov==2.5.1
 pytest-django==3.1.2
 pytest-xdist==1.18.2


### PR DESCRIPTION
* `py` is a direct dependency of `pytest`
* I have no idea where we got `pygments` from