### PR TITLE
Remove djangocms-admin-style

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,6 @@ django-filer==1.4.4
 djangocms-text-ckeditor==3.7.0
 djangocms-picture==2.1.3
 djangocms-link==2.3.1
-djangocms-admin-style==1.3.0
 raven
 pdfkit==0.6.1
 pyqrcode


### PR DESCRIPTION
It is a direct dependency of django-cms, so we don't need to list it as
a top-level dependency.