### PR TITLE
Use the enum name for `normal`

### DIFF
--- a/assets/js/select_seats.js
+++ b/assets/js/select_seats.js
@@ -100,7 +100,7 @@ function setupSelectSeats(config) {
                 info = [
                     "<div>", seatObject.name, "<br>",
                     "Student: ", pricing["student"], "kr", "<br>",
-                    "Normal: ", pricing["normal"], "kr", "<br>",
+                    "Fullpris: ", pricing["normal"], "kr", "<br>",
                     "</div>"
                 ].join("")
 


### PR DESCRIPTION
A friend of mine noted the use of `Normal` and `Student` for the two pricing options, where `Normal` sounds a bit weird as it implies students are not normal.

Looking in the code we actually call this `Fullpris`, which makes much more sense. This fixes that.