### PR TITLE
Adds table styling to `show_detail` page.

### DIFF
--- a/assets/css/tables.css
+++ b/assets/css/tables.css
@@ -1,0 +1,7 @@
+.costumer-table-data thead {
+  text-align: left;
+}
+
+.costumer-table-data th, .costumer-table-data td {
+  padding-right: 15px;
+}

--- a/karspexet/assets.py
+++ b/karspexet/assets.py
@@ -15,6 +15,7 @@ css = Bundle(
         "css/select_seats.css",
         "css/menu.css",
         "css/payment.css",
+        "css/tables.css",
     ),
     Bundle(
         "css/fonts.css",

--- a/karspexet/templates/economy/show_detail.html
+++ b/karspexet/templates/economy/show_detail.html
@@ -33,7 +33,7 @@
 
 <h3>Besökare</h3>
 
-<table>
+<table class="costumer-table-data">
   <thead>
     <tr>
       <th>Sektion</th>


### PR DESCRIPTION
This is a small PR moving the view from:
<img width="641" alt="image" src="https://user-images.githubusercontent.com/8898485/56865838-c1fad280-69d2-11e9-8564-f3bce45b0808.png">
To:
<img width="722" alt="image" src="https://user-images.githubusercontent.com/8898485/56865829-ab547b80-69d2-11e9-9d6a-cd1a23eea45c.png">
