### PR TITLE
Update dependency installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Skapa en `env.json`-fil med följande för att få stripe-integrationen att fung
 För att installera alla appens beroenden körs kommandot:
 
 ```sh
-pip install -r requirements/dev.txt
+pip install -U pipenv
+pipenv install --dev
 ```
 
 För datalagring används en Postgres server som förväntas finnas på port `5432`.


### PR DESCRIPTION
We use pipenv now, the readme should reflect that.