### PR TITLE
Add simple logging config with shorter timestamps

### DIFF
--- a/karspexet/settings.py
+++ b/karspexet/settings.py
@@ -283,3 +283,39 @@ STATICFILES_FINDERS = [
     "django_assets.finders.AssetsFinder",
 ]
 STATIC_ROOT = "staticfiles"
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "root": {"level": "INFO", "handlers": ["stdout"]},
+    "formatters": {
+        "default": {
+            "format": "[%(asctime)s] %(name)s: %(message)s",
+            "datefmt": "%H:%M:%S",
+        },
+        "django.server": {
+            "()": "django.utils.log.ServerFormatter",
+            "format": "[%(asctime)s] %(message)s",
+            "datefmt": "%H:%M:%S",
+        },
+    },
+    "handlers": {
+        "null": {"class": "logging.NullHandler"},
+        "stdout": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
+            "formatter": "default",
+        },
+        "django.server": {
+            "class": "logging.StreamHandler",
+            "formatter": "django.server",
+        },
+    },
+    "loggers": {
+        "django.server": {
+            "handlers": ["django.server"],
+            "level": "INFO",
+        },
+    },
+}

--- a/karspexet/settings.py
+++ b/karspexet/settings.py
@@ -167,16 +167,15 @@ try:
     with open(BASE_DIR + "/env.json") as env_json:
         ENV = json.load(env_json)
 except FileNotFoundError:
-    import sys
-    print("""
-    ================================================================================
-    No env.json settings file found.
+    import textwrap
+    raise SystemExit(textwrap.dedent("""
+    ================ ERROR ================
+    ERROR: No env.json settings file found.
 
     Try starting with the sample one:
 
     cp env.json.sample env.json
-    """, file=sys.stderr)
-    exit(1)
+    """))
 
 EMAIL_BACKEND = ENV.get("email_backend", 'django.core.mail.backends.smtp.EmailBackend')
 PAYMENT_PROCESS = ENV.get("payment_process", "not set")


### PR DESCRIPTION
Since our logs in local development is always regarding the current date,
we can make them a bit shorter and snappier.

Before:

   [04/Dec/2019 23:38:45] "POST /ticket/stripe-webhooks/ HTTP/1.1" 200 0

After:

   [23:38:45] "POST /ticket/stripe-webhooks/ HTTP/1.1" 200 0

This also configures the root logger to print everything to stdout. I'm not
sure where we directed the logs before.


---

Passar ändå på att snygga till varningen när man saknar env.json när jag ändå är inne i samma fil. (Jag har en förkärlek för `raise SystemExit` ;))

I denna PR funderar jag lite på hur vår existerande loggning fungerar - kan denna nya config orsaka några problem, eller bör det fungera även med det gamla? Tex om vi loggar till syslog eller någon viss fil.
Tänker iaf att det är lite enklare att bara logga till stdout, lättare att läsa i konsolen vid lokal utveckling och enkelt att konfigurera outputen till en fil i prod.