### PR TITLE
Add skeleton for stripe webhook handlers

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,5 +1,7 @@
 ---
 engines:
+  prospector:
+    enabled: false
   pylint:
     enabled: true
     python_version: 3

--- a/karspexet/ticket/tests/test_views.py
+++ b/karspexet/ticket/tests/test_views.py
@@ -62,6 +62,18 @@ class TestSelect_seats(TestCase):
         self.assertContains(response, "Köp biljetter för Uppsättningen")
 
 
+class TestWebhooks(TestCase):
+    def test_stripe_webhooks(self):
+        payload = {"type": "unknown"}
+        url = reverse(views.stripe_webhooks)
+        response = self.client.post(url, data=payload, content_type="application/json")
+        assert response.status_code == 400
+
+        payload = {"type": "payment_intent.succeeded"}
+        response = self.client.post(url, data=payload, content_type="application/json")
+        assert response.status_code == 400
+
+
 @pytest.mark.django_db
 def test_cancelling_a_discounted_reservation_allows_voucher_for_reuse(show, user):
     seat = Seat.objects.first()

--- a/karspexet/ticket/urls.py
+++ b/karspexet/ticket/urls.py
@@ -12,5 +12,6 @@ urlpatterns = [
     url(r"^ticket/(?P<reservation_id>\d+)-(?P<ticket_code>[A-Z0-9]+).pdf$", views.ticket_pdf, name="ticket_pdf"),
     url(r"^reservation/(?P<reservation_code>[A-Z0-9]+)/send_reservation_email$", views.send_reservation_email, name="send_reservation_email"),
     url(r"^cancel/(?P<show_id>\d+)/?$", views.cancel_reservation, name="cancel_reservation"),
+    url(r"^stripe-webhooks/$", views.stripe_webhooks),
     url(r"^$", views.home, name="ticket_home"),
 ]


### PR DESCRIPTION
Ett första mini-steg till att handera PaymentIntent - dessa lägger bara till en ny vy som lyssnar på anropen men inte gör något vettigt.

Antingen kan vi merge:a denna och arbeta vidare, eller så dokumenterar jag bara det lilla steget för att någon annan / jag själv kan ha något att bygga vidare från.



Att köra detta lokalt är relativt enkelt:

Prep:
1. Skapa ett testkonto på Stripe
2. Installera Stripe CLI: https://stripe.com/docs/stripe-cli
3. Kör `stripe login` och följ instruktionerna
4. Uppdatera din `env.json`-fil med API-nycklarna från: https://dashboard.stripe.com/test/apikeys

Vid utveckling:
4. I terminal 1 kör du servern med `./manage.py runserver`
5. I terminal 2 kör du `stripe listen --forward-to localhost:8000/ticket/stripe-webhooks/`
6. I terminal 3 kan du nu trigga de event du vill testa med tex. `stripe trigger payment_intent.succeeded`