### PR TITLE
Fix linter warnings

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+assets/bundles/
+assets/fonts/icomoon/demo-files/demo.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,25 +1,13 @@
 {
-    "env": {
-        "amd": true,
-        "browser": true
-    },
-    "extends": "eslint:recommended",
-    "rules": {
-        "indent": [
-            "error",
-            2
-        ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "double"
-        ],
-        "semi": [
-            "error",
-            "never"
-        ]
-    }
+  "env": {
+    "amd": true,
+    "browser": true
+  },
+  "extends": "eslint:recommended",
+  "rules": {
+    "indent": ["error", 2, { "SwitchCase": 1 }],
+    "linebreak-style": ["error", "unix"],
+    "quotes": ["error", "double"],
+    "semi": ["error", "never"]
+  }
 }

--- a/assets/css/select_seats.css
+++ b/assets/css/select_seats.css
@@ -3,7 +3,7 @@ section.select-seats {
     flex-direction: row;
 }
 
-div.seat-info div {
+div.seat-info > * {
     border: 1px dotted;
     padding: 0.5rem;
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,20 +1,20 @@
 "use strict"
 
-!function(window, document) {
-    function initApplication(config) {
-        window.setupSelectSeats(config)
-        window.setupPayment(config)
-        window.setupBookingOverview(config)
-    }
+!(function(window, document) {
+  function initApplication(config) {
+    window.setupSelectSeats(config)
+    window.setupPayment(config)
+    window.setupBookingOverview(config)
+  }
 
-    function bootstrap(event) {
-        var readyState = event.target.readyState
-        switch (readyState) {
-        case "complete":
-            initApplication(window.config)
-            break
-        }
+  function bootstrap(event) {
+    var readyState = event.target.readyState
+    switch (readyState) {
+      case "complete":
+        initApplication(window.config)
+        break
     }
+  }
 
-    document.addEventListener("readystatechange", bootstrap)
-}(window, document)
+  document.addEventListener("readystatechange", bootstrap)
+})(window, document)

--- a/assets/js/booking_overview.js
+++ b/assets/js/booking_overview.js
@@ -1,26 +1,22 @@
 function remainingTime(timeElement, outputElement) {
-    var now = new Date(),
-        timeout = new Date(timeElement.dataset.time),
-        timeRemaining = (timeout - now) / 1000,
-        secondsRemaining = Math.floor(timeRemaining) % 60,
-        minutesRemaining = Math.floor(timeRemaining / 60)
+  var now = new Date(),
+    timeout = new Date(timeElement.dataset.time),
+    timeRemaining = (timeout - now) / 1000,
+    secondsRemaining = Math.floor(timeRemaining) % 60,
+    minutesRemaining = Math.floor(timeRemaining / 60)
 
-    outputElement.innerHTML = minutesRemaining + " minuter och " + secondsRemaining + " sekunder"
+  outputElement.innerHTML = minutesRemaining + " minuter och " + secondsRemaining + " sekunder"
 }
 function setupBookingOverview() {
-    Array.prototype.forEach.call(
-        document.querySelectorAll(".fn-session-timeout"),
-        function (element) {
-            var timeElement = element.querySelector("time"),
-                outputElement = element.querySelector(".fn-session-timeout-output")
-            setInterval(
-                function() { remainingTime(timeElement, outputElement) },
-                1000
-            )
-        }
-    )
+  Array.prototype.forEach.call(document.querySelectorAll(".fn-session-timeout"), function(element) {
+    var timeElement = element.querySelector("time"),
+      outputElement = element.querySelector(".fn-session-timeout-output")
+    setInterval(function() {
+      remainingTime(timeElement, outputElement)
+    }, 1000)
+  })
 }
 
-!function(window) {
-    window.setupBookingOverview = setupBookingOverview
-}(window)
+!(function(window) {
+  window.setupBookingOverview = setupBookingOverview
+})(window)

--- a/assets/js/select_seats.js
+++ b/assets/js/select_seats.js
@@ -1,193 +1,217 @@
 function disableSubmitButton() {
-    document.querySelector("#no-seats-selected").hidden = false
-    document.querySelector("#book-submit-button").disabled = true
+  document.querySelector("#no-seats-selected").hidden = false
+  document.querySelector("#book-submit-button").disabled = true
 }
 
 function enableSubmitButton() {
-    document.querySelector("#book-submit-button").disabled = false
-    document.querySelector("#no-seats-selected").hidden = true
+  document.querySelector("#book-submit-button").disabled = false
+  document.querySelector("#no-seats-selected").hidden = true
 }
 
 function setupSeatMapSelection(config) {
-    var booking = {}
+  var booking = {}
 
-    var isMobile = /Mobi/.test(navigator.userAgent)
+  var isMobile = /Mobi/.test(navigator.userAgent)
 
-    function selectSeat(event) {
-        var seat = event.target.id
-        if (booking.hasOwnProperty(seat)) {
-            removeSeat(seat)
-        } else {
-            addSeat(seat)
-        }
+  function selectSeat(event) {
+    var seat = event.target.id
+    if (booking.hasOwnProperty(seat)) {
+      removeSeat(seat)
+    } else {
+      addSeat(seat)
     }
+  }
 
-    function addSeat(seat) {
-        var seatId = seat.replace("seat-", ""),
-            seatElement = document.querySelector("#" + seat),
-            classes = seatElement.getAttribute("class")
-        booking[seat] = {id: seatId, value: null}
+  function addSeat(seat) {
+    var seatId = seat.replace("seat-", ""),
+      seatElement = document.querySelector("#" + seat),
+      classes = seatElement.getAttribute("class")
+    booking[seat] = { id: seatId, value: null }
 
-        seatElement.setAttribute("class", classes + " selected-seat")
-        renderBooking()
+    seatElement.setAttribute("class", classes + " selected-seat")
+    renderBooking()
+  }
+
+  function removeSeat(seat) {
+    delete booking[seat]
+    var seatElement = document.querySelector("#" + seat),
+      classes = seatElement.getAttribute("class"),
+      newClasses = classes
+        .split(" ")
+        .filter(function(x) {
+          return x != "selected-seat"
+        })
+        .join(" ")
+
+    seatElement.setAttribute("class", newClasses)
+    renderBooking()
+  }
+
+  function selectSeatType(event) {
+    var target = event.target,
+      seatId = target.dataset.id,
+      seatType = target.value,
+      seatKey = "seat-" + seatId
+
+    booking[seatKey].value = seatType
+    renderBooking()
+  }
+
+  function renderBooking() {
+    var output = ""
+    if (Object.keys(booking).length === 0) {
+      disableSubmitButton()
+    } else {
+      enableSubmitButton()
+      Object.keys(booking).forEach(function(seatId) {
+        output += renderSeatForm(booking[seatId])
+      })
     }
+    document.querySelector("#booking").innerHTML = output
+    Array.prototype.forEach.call(document.querySelectorAll("#booking select"), function(select) {
+      select.addEventListener("change", selectSeatType)
+    })
+  }
 
-    function removeSeat(seat) {
-        delete booking[seat]
-        var seatElement = document.querySelector("#" + seat),
-            classes = seatElement.getAttribute("class"),
-            newClasses = classes.split(" ").filter(function(x) { return x != "selected-seat"}).join(" ")
+  function renderSeatForm(seat) {
+    var seatId = seat.id,
+      seatType = seat.value,
+      seatObject = config.allSeats["seat-" + seatId],
+      displayName = seatObject.name,
+      pricing = config.pricings[seatObject.group]
 
-        seatElement.setAttribute("class", newClasses)
-        renderBooking()
+    function option(seatType, selectedSeatType) {
+      var selectedString = seatType === selectedSeatType ? " selected" : ""
+      return [
+        '<option value="',
+        seatType,
+        '" ',
+        selectedString,
+        ">",
+        seatType[0].toUpperCase(),
+        seatType.slice(1),
+        " (",
+        pricing[seatType],
+        "kr)",
+        "</option>",
+      ].join("")
     }
+    return [
+      "<div><label>",
+      displayName,
+      ": ",
+      '<select name="seat_',
+      seatId,
+      '" data-id="',
+      seatId,
+      '">',
+      '<option value="">(Välj biljettyp)</option>',
+      option("normal", seatType),
+      option("student", seatType),
+      "</select></label></div>",
+    ].join("")
+  }
 
-    function selectSeatType(event) {
-        var target = event.target,
-            seatId = target.dataset.id,
-            seatType = target.value,
-            seatKey = "seat-" + seatId
+  Object.keys(config.allSeats).forEach(function(seat) {
+    if (isMobile) return
 
-        booking[seatKey].value = seatType
-        renderBooking()
-    }
-
-    function renderBooking() {
-        var output = ""
-        if (Object.keys(booking).length === 0) {
-            disableSubmitButton()
-        } else {
-            enableSubmitButton()
-            Object.keys(booking).forEach(function(seatId) {
-                output += renderSeatForm(booking[seatId])
-            })
-        }
-        document.querySelector("#booking").innerHTML = output
-        Array.prototype.forEach.call(
-            document.querySelectorAll("#booking select"),
-            function (select) { select.addEventListener("change", selectSeatType) }
-        )
-    }
-
-    function renderSeatForm(seat) {
-        var seatId = seat.id,
-            seatType = seat.value,
-            seatObject = config.allSeats["seat-" + seatId],
-            displayName = seatObject.name,
-            pricing = config.pricings[seatObject.group]
-
-        function option(seatType, selectedSeatType) {
-            var selectedString = seatType === selectedSeatType ? " selected" : ""
-            return [
-                "<option value=\"", seatType, "\" ", selectedString, ">",
-                seatType[0].toUpperCase(), seatType.slice(1),
-                " (", pricing[seatType], "kr)",
-                "</option>"
-            ].join("")
-        }
-        return [
-            "<div><label>", displayName, ": ",
-            "<select name=\"seat_", seatId, "\" data-id=\"", seatId, "\">",
-            "<option value=\"\">(Välj biljettyp)</option>",
-            option("normal", seatType),
-            option("student", seatType),
-            "</select></label></div>"
+    var element = document.getElementById(seat),
+      seatObject = config.allSeats[seat]
+    element.addEventListener("mouseover", function() {
+      var pricing = config.pricings[seatObject.group],
+        info = [
+          "<div>",
+          seatObject.name,
+          "<br>",
+          "Student: ",
+          pricing["student"],
+          "kr",
+          "<br>",
+          "Fullpris: ",
+          pricing["normal"],
+          "kr",
+          "<br>",
+          "</div>",
         ].join("")
-    }
 
-    Object.keys(config.allSeats).forEach(function(seat) {
-        if (isMobile) return
-
-        var element = document.getElementById(seat),
-            seatObject = config.allSeats[seat]
-        element.addEventListener("mouseover", function() {
-            var pricing = config.pricings[seatObject.group],
-                info = [
-                    "<div>", seatObject.name, "<br>",
-                    "Student: ", pricing["student"], "kr", "<br>",
-                    "Fullpris: ", pricing["normal"], "kr", "<br>",
-                    "</div>"
-                ].join("")
-
-            document.querySelector(".seat-info").innerHTML = info
-        })
-
-        element.addEventListener("mouseout", function() {
-            document.querySelector(".seat-info").innerHTML = ""
-        })
+      document.querySelector(".seat-info").innerHTML = info
     })
 
-    Array.prototype.forEach.call(
-        document.querySelectorAll(".seat:not(.taken-seat)"),
-        function makeSeatAvailable(seat) {seat.addEventListener("click", selectSeat)}
-    )
+    element.addEventListener("mouseout", function() {
+      document.querySelector(".seat-info").innerHTML = ""
+    })
+  })
+
+  Array.prototype.forEach.call(
+    document.querySelectorAll(".seat:not(.taken-seat)"),
+    function makeSeatAvailable(seat) {
+      seat.addEventListener("click", selectSeat)
+    },
+  )
 }
 
 function setupFreeSeating(config) {
-    var booking = {
-        student: 0,
-        normal: 0,
+  var booking = {
+    student: 0,
+    normal: 0,
+  }
+
+  function setNumberOfSeats(seatType, numberOfSeats) {
+    var saneNumberOfSeats = Number(numberOfSeats) < 0 ? 0 : Number(numberOfSeats)
+    booking[seatType] = saneNumberOfSeats
+  }
+
+  function renderBooking() {
+    var bookingElement = document.getElementById("booking")
+    if (booking.student === 0 && booking.normal === 0) {
+      disableSubmitButton()
+      bookingElement.innerText = ""
+
+      return
     }
 
-    function setNumberOfSeats(seatType, numberOfSeats) {
-        var saneNumberOfSeats = Number(numberOfSeats) < 0 ? 0 : Number(numberOfSeats)
-        booking[seatType] = saneNumberOfSeats
+    enableSubmitButton()
+    var studentTotal = (booking.student || 0) * (config.pricings.student || 0)
+    var normalTotal = (booking.normal || 0) * (config.pricings.normal || 0)
+    var totalPrice = studentTotal + normalTotal
+    bookingElement.innerText = "Totalsumma: " + totalPrice
+  }
+
+  function setupChangeNumberOfSeats(seatType) {
+    return function changeSeats(event) {
+      var numberOfSeats = Number(event.target.value)
+      if (numberOfSeats < 0) {
+        numberOfSeats = 0
+      }
+
+      setNumberOfSeats(seatType, numberOfSeats)
+      renderBooking()
     }
+  }
 
-    function renderBooking() {
-        var bookingElement = document.getElementById("booking")
-        if (booking.student === 0 && booking.normal === 0) {
-            disableSubmitButton()
-            bookingElement.innerText = ""
-
-            return
-        }
-
-        enableSubmitButton()
-        var studentTotal = (booking.student || 0) * (config.pricings.student || 0)
-        var normalTotal = (booking.normal || 0) * (config.pricings.normal || 0)
-        var totalPrice = studentTotal + normalTotal
-        bookingElement.innerText = "Totalsumma: " + totalPrice
+  var numberOfSeatsElements = document.getElementsByClassName("number-of-seats")
+  Array.prototype.forEach.call(numberOfSeatsElements, function setupEventListeners(field) {
+    var seatType = field.getAttribute("name")
+    setNumberOfSeats(seatType, field.value)
+    if (typeof field.value !== "number") {
+      field.value = 0
     }
-
-    function setupChangeNumberOfSeats(seatType) {
-        return function changeSeats(event) {
-            var numberOfSeats = Number(event.target.value)
-            if (numberOfSeats < 0) {
-                numberOfSeats = 0
-            }
-
-            setNumberOfSeats(seatType, numberOfSeats)
-            renderBooking()
-        }
-    }
-
-    var numberOfSeatsElements = document.getElementsByClassName("number-of-seats")
-    Array.prototype.forEach.call(
-        numberOfSeatsElements,
-        function setupEventListeners(field) {
-            var seatType = field.getAttribute("name")
-            setNumberOfSeats(seatType, field.value)
-            if (typeof(field.value) !== "number") {
-                field.value = 0
-            }
-            renderBooking()
-            field.addEventListener("change", setupChangeNumberOfSeats(seatType))
-        }
-    )
+    renderBooking()
+    field.addEventListener("change", setupChangeNumberOfSeats(seatType))
+  })
 }
 
 function setupSelectSeats(config) {
-    if (!config || !config.seatSelection) return
-    config = config.seatSelection
+  if (!config || !config.seatSelection) return
+  config = config.seatSelection
 
-    if (config.freeSeating) {
-        return setupFreeSeating(config)
-    } else {
-        return setupSeatMapSelection(config)
-    }
+  if (config.freeSeating) {
+    return setupFreeSeating(config)
+  } else {
+    return setupSeatMapSelection(config)
+  }
 }
 
-!function(window) {
-    window.setupSelectSeats = setupSelectSeats
-}(window)
+!(function(window) {
+  window.setupSelectSeats = setupSelectSeats
+})(window)

--- a/factories/fixtures.py
+++ b/factories/fixtures.py
@@ -1,6 +1,8 @@
 import pytest
-from factories import factories as f
 from django.utils import timezone
+
+from factories import factories as f
+
 
 @pytest.fixture
 def show():
@@ -21,5 +23,3 @@ def show():
 @pytest.fixture
 def user():
     return f.CreateStaffUser(username="test", password="test")
-
-

--- a/karspexet/economy/tests/test_views.py
+++ b/karspexet/economy/tests/test_views.py
@@ -1,12 +1,9 @@
 # coding: utf-8
-from django.contrib.auth.models import User
-from django.http import HttpRequest
-from django.test import TestCase, Client
+from django.test import Client, TestCase
 from django.utils import timezone
 
 from factories import factories as f
 
-from karspexet.economy import views
 
 class TestOverview(TestCase):
     def setUp(self):

--- a/karspexet/settings.py
+++ b/karspexet/settings.py
@@ -232,7 +232,7 @@ CMS_PLACEHOLDER_CONF = {
             {
                 'plugin_type': 'TextPlugin',
                 'values': {
-                    'body':'<p>Lorem ipsum dolor sit amet...</p>',
+                    'body': '<p>Lorem ipsum dolor sit amet...</p>',
                 },
             },
         ],

--- a/karspexet/show/models.py
+++ b/karspexet/show/models.py
@@ -30,7 +30,7 @@ class Show(models.Model):
     @staticmethod
     def ticket_coverage(show=None):
         if show is None:
-            show_ids = Show.objects.order_by("-id").values_list('id',flat=True)
+            show_ids = Show.objects.order_by("-id").values_list('id', flat=True)
         else:
             show_ids = [show.id]
 

--- a/karspexet/ticket/admin.py
+++ b/karspexet/ticket/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from karspexet.ticket.models import Account, Reservation, Ticket, Voucher, PricingModel
+from karspexet.ticket.models import Account, PricingModel, Reservation, Ticket, Voucher
 
 
 class ReservationAdmin(admin.ModelAdmin):
@@ -20,8 +20,10 @@ class VoucherAdmin(admin.ModelAdmin):
 class PricingModelAdmin(admin.ModelAdmin):
     list_display = ('seating_group', 'prices', 'valid_from')
 
+
 class AccountAdmin(admin.ModelAdmin):
     list_display = ('name', 'email', 'phone')
+
 
 admin.site.register(Reservation, ReservationAdmin)
 admin.site.register(Ticket, TicketAdmin)

--- a/karspexet/ticket/forms.py
+++ b/karspexet/ticket/forms.py
@@ -1,4 +1,5 @@
 from django import forms
 
+
 class CustomerEmailForm(forms.Form):
     email = forms.EmailField(required=True, label="E-postadress")

--- a/karspexet/ticket/models.py
+++ b/karspexet/ticket/models.py
@@ -19,12 +19,13 @@ TICKET_TYPES = [
     ("student", "Student"),
 ]
 
-def _generate_random_code():
-    return get_random_string(allowed_chars=ascii_uppercase+digits)
+
+def _generate_random_code(length=12):
+    return get_random_string(length=length, allowed_chars=ascii_uppercase + digits)
 
 
 def _generate_voucher_code():
-    return get_random_string(length=16, allowed_chars=ascii_uppercase+digits)
+    return _generate_random_code(length=16)
 
 
 def _next_fifteenth_september():
@@ -162,6 +163,7 @@ class Voucher(models.Model):
 
     def __str__(self):
         return f"id={self.id} amount={self.amount} code={self.code}"
+
 
 class Discount(models.Model):
     """

--- a/karspexet/ticket/payment.py
+++ b/karspexet/ticket/payment.py
@@ -56,7 +56,7 @@ class PaymentProcess:
         # This _should_ be done in Reservation.save, but we can afford a few CPU cycles to know that this happens.
         self.reservation.calculate_ticket_price_and_total()
         if self.reservation.total > 0:
-          self._charge_card()
+            self._charge_card()
 
         self.reservation = self._finalize_reservation()
         self._send_mail_to_customer()
@@ -102,6 +102,7 @@ class PaymentProcess:
     def _send_mail_to_customer(self):
         return send_ticket_email_to_customer(self.reservation, self.account.email, self.account.name)
 
+
 class FakePaymentProcess(PaymentProcess):
     def _charge_card(self):
         if self.data['payment_success'] == 'true':
@@ -113,7 +114,7 @@ class FakePaymentProcess(PaymentProcess):
 class StripePaymentProcess(PaymentProcess):
     def _charge_card(self):
         assert self.reservation.total > 0, "We cannot charge a reservation without a total price"
-        amount = self.reservation.total * 100 # Öre
+        amount = self.reservation.total * 100  # Öre
         stripe_token = self.data['stripeToken']
 
         try:

--- a/karspexet/ticket/tests/test_models.py
+++ b/karspexet/ticket/tests/test_models.py
@@ -1,18 +1,17 @@
-import pytest
-
 from datetime import date, datetime
+from unittest.mock import patch
+
+import pytest
 from dateutil.relativedelta import relativedelta
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
 
-from unittest.mock import patch
-
 from factories import factories as f
-
-from karspexet.ticket.models import PricingModel, Reservation, Ticket, Voucher, Discount, AlreadyDiscountedException, InvalidVoucherException
-from karspexet.venue.models import Seat
-from django.core.exceptions import ValidationError
 from factories.fixtures import show, user
+from karspexet.ticket.models import (AlreadyDiscountedException, InvalidVoucherException, PricingModel, Reservation,
+                                     Ticket, Voucher)
+from karspexet.venue.models import Seat
 
 
 class TestReservation(TestCase):
@@ -61,7 +60,6 @@ class TestReservation(TestCase):
 
         assert reservation in Reservation.objects.all()
         assert reservation not in Reservation.active.all()
-
 
     def test_ticket_price_and_total(self):
         timestamp = timezone.now() - relativedelta(days=1)
@@ -124,6 +122,7 @@ class TestPricingModel(TestCase):
 
         assert seat.price_for_type('student') == 200
         assert seat.price_for_type('student', one_day_ago) == 150
+
 
 class TestTicket(TestCase):
     def setUp(self):
@@ -216,7 +215,6 @@ class TestDiscount:
 
         assert discount.amount == 100
         assert reservation.total == 150
-
 
     def test_a_voucher_expires_nextcoming_fifteenth_of_september(self):
         user = f.CreateStaffUser(username="test", password="test")

--- a/karspexet/ticket/views.py
+++ b/karspexet/ticket/views.py
@@ -102,7 +102,8 @@ def select_seats(request, show_slug):
             else:
                 messages.error(request, "Det finns inte tillräckligt många biljetter kvar.")
 
-        else: # Select seats from seatmap
+        else:
+            # Select seats from seatmap
             seat_params = _seat_specifications(request)
             if not _all_seats_available(taken_seats_qs, seat_params.keys()):
                 messages.error(request, "Vissa av platserna du valde har redan blivit bokade av någon annan")
@@ -113,7 +114,7 @@ def select_seats(request, show_slug):
                 reservation.save()
                 return redirect("booking_overview", show_slug=show.slug)
 
-    taken_seats = set(map(int,set().union(*[r.tickets.keys() for r in taken_seats_qs.all()])))
+    taken_seats = set(map(int, set().union(*[r.tickets.keys() for r in taken_seats_qs.all()])))
 
     pricings, seats = _build_pricings_and_seats(show.venue)
     if show.free_seating:
@@ -144,7 +145,6 @@ def booking_overview(request, show_slug):
         messages.warning(request, "Du måste välja minst en plats")
         return redirect("select_seats", show_slug=show_slug)
 
-
     if show.free_seating:
         reserved_seats = {}
         for seat in reservation.seats():
@@ -167,7 +167,7 @@ def booking_overview(request, show_slug):
         ]
         num_tickets = sum((group['count'] for (ticket_type, group) in reserved_seats.items()))
     else:
-        reserved_seats = {seat.id:seat for seat in reservation.seats()}
+        reserved_seats = {seat.id: seat for seat in reservation.seats()}
         seats = [
             "%s: %s (%s, %dkr)" % (
                 reserved_seats[int(id)].group.name,
@@ -277,16 +277,14 @@ def ticket_pdf(request, reservation_id, ticket_code):
     ticket = reservation.ticket_set().get(ticket_code=ticket_code)
 
     template = TemplateResponse(request, "ticket_detail.html", {
-            'reservation': reservation,
-            'show': reservation.show,
-            'venue': reservation.show.venue,
-            'production': reservation.show.production,
-            'ticket': ticket,
-            'seat': ticket.seat,
-            'qr_code': _qr_code(request)
-        },
-        content_type="utf-8"
-    ).render()
+        'reservation': reservation,
+        'show': reservation.show,
+        'venue': reservation.show.venue,
+        'production': reservation.show.production,
+        'ticket': ticket,
+        'seat': ticket.seat,
+        'qr_code': _qr_code(request)
+    }, content_type="utf-8").render()
 
     pdfkit_options = {
         'page-size': 'A5',
@@ -369,20 +367,20 @@ def _all_seats_available(qs, seat_ids):
 
 def _seat_specifications(request):
     return {
-        seat.replace("seat_", ""):ticket_type
-            for seat,ticket_type in request.POST.items()
-            if seat.startswith("seat_")
+        seat.replace("seat_", ""): ticket_type
+        for seat, ticket_type in request.POST.items()
+        if seat.startswith("seat_")
     }
 
 
 def _some_seat_is_missing_ticket_type(seat_params):
-    return any(not ticket_type for ( seat,ticket_type ) in seat_params.items())
+    return any(not ticket_type for (seat, ticket_type) in seat_params.items())
 
 
 def _build_pricings_and_seats(venue):
     qs = PricingModel.objects.select_related('seating_group').filter(seating_group__venue_id=venue)
     pricings = {
-        pricing.seating_group_id : pricing.prices
+        pricing.seating_group_id: pricing.prices
         for pricing in qs.all()
     }
 

--- a/karspexet/venue/admin.py
+++ b/karspexet/venue/admin.py
@@ -36,6 +36,7 @@ class SeatingGroupAdmin(admin.ModelAdmin):
 class SeatAdmin(admin.ModelAdmin):
     pass
 
+
 admin.site.register(Venue, VenueAdmin)
 admin.site.register(Seat, SeatAdmin)
 admin.site.register(SeatingGroup, SeatingGroupAdmin)


### PR DESCRIPTION
Använder `prettier` för att fixa `eslint`-varningar (och strukturerar om koden lite för vissa bitar ska bli mer lättlästa), och fixar nästan alla flake8-varningar.

Jag har manuellt verifierat att "välj sittplats"-väljaren fortfarande fungerar efter refaktoreringen.

De varningar som jag inte fixar hänger ihop med pytest-fixtures, och det är eftersom jag inte riktigt har koll på bästa sättet att lösa det problemet. En sak att fixa nästa gång!