### PR TITLE
Apply voucher amounts to Stripe PaymentIntents

### DIFF
--- a/factories/factories.py
+++ b/factories/factories.py
@@ -1,5 +1,20 @@
-from factory.django import DjangoModelFactory
+import factory
 from django.contrib.auth.models import User
+from django.utils import timezone
+from factory.django import DjangoModelFactory
+
+
+class CreateStaffUser(DjangoModelFactory):
+    email = "ture@example.com"
+    is_staff = True
+
+    class Meta:
+        model = User
+
+    @factory.post_generation
+    def password(self, create, extracted, **kwargs):
+        self.set_password(extracted)
+        self.save()
 
 
 class CreateVenue(DjangoModelFactory):
@@ -21,6 +36,9 @@ class CreateSeat(DjangoModelFactory):
 
 
 class CreateShow(DjangoModelFactory):
+    date = timezone.now()
+    production = factory.SubFactory('factories.factories.CreateProduction')
+
     class Meta:
         model = 'show.show'
 
@@ -32,7 +50,8 @@ class CreateProduction(DjangoModelFactory):
 
 class CreateReservation(DjangoModelFactory):
     class Meta:
-        model = 'ticket.reservation'
+        model = 'ticket.Reservation'
+    session_timeout = timezone.now()
 
 
 class CreateAccount(DjangoModelFactory):
@@ -49,15 +68,10 @@ class CreateVoucher(DjangoModelFactory):
     class Meta:
         model = 'ticket.voucher'
 
+    amount = 100
+    created_by = factory.SubFactory(CreateStaffUser)
+
 
 class CreatePricingModel(DjangoModelFactory):
     class Meta:
         model = 'ticket.pricingmodel'
-
-
-def CreateStaffUser(username, password):
-    user = User.objects.create_user(username, email="ture@example.com")
-    user.set_password(password)
-    user.is_staff = True
-    user.save()
-    return user

--- a/karspexet/economy/tests/test_views.py
+++ b/karspexet/economy/tests/test_views.py
@@ -13,7 +13,7 @@ class TestOverview(TestCase):
         response = self.client.get("/economy/")
         assert response.status_code == 302
 
-        f.CreateStaffUser("ture", "test")
+        f.CreateStaffUser(username="ture", password="test")
         assert self.client.login(username="ture", password="test")
 
         response = self.client.get("/economy/")
@@ -34,7 +34,7 @@ class TestShowDetail(TestCase):
         response = self.client.get(f"/economy/{show.id}")
         assert response.status_code == 302
 
-        f.CreateStaffUser("ture", "test")
+        f.CreateStaffUser(username="ture", password="test")
         assert self.client.login(username="ture", password="test")
 
         response = self.client.get(f"/economy/{show.id}")


### PR DESCRIPTION
Makes sure we only create new PaymentIntents when needed, instead of on
every request, which makes it possible for us to update them when the user
applies a voucher.

This also adds a basic sanity test to make sure the booking_overview page
doesn't crash.