### PR TITLE
Bättre validering och felhantering i betalningsformuläret

### DIFF
--- a/karspexet/templates/ticket/payment.html
+++ b/karspexet/templates/ticket/payment.html
@@ -66,15 +66,15 @@
     <div class="group">
       <label>
         <span>Namn</span>
-        <input name="name" class="field" placeholder="Jane Doe" />
+        <input name="name" class="field" placeholder="Jane Doe" autocomplete="name" required />
       </label>
       <label>
         <span>Telefonnummer</span>
-        <input name="phone" class="field" placeholder="(123) 456-7890" type="tel" />
+        <input name="phone" class="field" placeholder="(123) 456-7890" type="tel" autocomplete="tel" />
       </label>
       <label>
         <span>E-postadress</span>
-        <input name="email" class="field" placeholder="" type="email" />
+        <input name="email" class="field" placeholder="" type="email" autocomplete="email" required />
       </label>
     </div>
     {% include payment_partial %}


### PR DESCRIPTION
Improve payment error messages

* Only show spinner after a few milliseconds, so immediate errors don't
flash it

* Show Stripe errors in our normal .error element for better styling

* Remove unused code

Add autocomplete and required attributes to payment form

We always want a name and email on our payments, so let's make the browser
help out a bit.