### PR TITLE
Modify payment intent if reservation changed

### DIFF
--- a/karspexet/ticket/payment.py
+++ b/karspexet/ticket/payment.py
@@ -132,7 +132,11 @@ class StripePaymentProcess(PaymentProcess):
 def get_payment_intent_from_reservation(request, reservation):
     payment_intent_id = request.session.get("payment_intent_id")
     if payment_intent_id:
-        return stripe.PaymentIntent.retrieve(payment_intent_id)
+        payment_intent = stripe.PaymentIntent.retrieve(payment_intent_id)
+        amount = reservation.get_amount()
+        if payment_intent.amount != amount:
+            return stripe.PaymentIntent.modify(payment_intent_id, amount=amount)
+
     intent = stripe.PaymentIntent.create(
         amount=reservation.get_amount(),
         currency="sek",

--- a/karspexet/ticket/tests/test_payment.py
+++ b/karspexet/ticket/tests/test_payment.py
@@ -1,13 +1,18 @@
 # coding: utf-8
+from unittest import mock
 from django.core import mail
 import pytest
 import stripe
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.shortcuts import reverse
+from django.test import RequestFactory
 from django.utils import timezone
 
 from factories import factories as f
 from factories.fixtures import show  # noqa
 from karspexet.ticket.models import Seat, Ticket
-from karspexet.ticket.payment import handle_successful_payment
+from karspexet.ticket.payment import handle_successful_payment, get_payment_intent_from_reservation
+from karspexet.ticket import views
 
 
 @pytest.mark.django_db
@@ -31,6 +36,83 @@ def test_handle_successful_payment(show):
     assert mail.outbox[0].to == ["Frank Hamer <frank@hamer.com>"]
 
     assert Ticket.objects.count() == 1
+
+
+@pytest.mark.django_db
+class TestGetPaymentIntentFromReservation:
+    def test_create_payment_intent_if_none_stored_in_session(self, show):
+        reservation = self._build_reservation(show)
+        request = self._build_request(reservation)
+
+        with mock.patch("karspexet.ticket.payment.stripe") as mock_stripe:
+            mock_stripe.PaymentIntent.create.return_value = FakeIntent(id="fake_payment_intent_id")
+            intent = get_payment_intent_from_reservation(request, reservation)
+
+        assert mock_stripe.PaymentIntent.create.called
+        assert request.session["payment_intent_id"] == "fake_payment_intent_id"
+
+    def test_retrieve_payment_intent_if_one_is_stored_in_session(self, show):
+        reservation = self._build_reservation(show)
+        request = self._build_request(reservation)
+
+        request.session["payment_intent_id"] = "fake_payment_intent_id"
+        with mock.patch("karspexet.ticket.payment.stripe") as mock_stripe:
+            mock_stripe.PaymentIntent.retrieve.return_value = FakeIntent(
+                id="fake_payment_intent_id"
+            )
+            intent = get_payment_intent_from_reservation(request, reservation)
+
+        assert mock_stripe.PaymentIntent.retrieve.called
+        assert request.session["payment_intent_id"] == "fake_payment_intent_id"
+
+    def test_modify_payment_intent_if_reservation_amount_changed(self, show):
+        reservation = self._build_reservation(show)
+        old_amount = reservation.get_amount()
+        another_seat = Seat.objects.all()[1]
+        reservation.tickets[str(another_seat.id)] = "normal"
+        reservation.save()
+        updated_amount = reservation.get_amount()
+
+        request = self._build_request(reservation)
+
+        request.session["payment_intent_id"] = "fake_payment_intent_id"
+
+        with mock.patch("karspexet.ticket.payment.stripe") as mock_stripe:
+            mock_stripe.PaymentIntent.retrieve.return_value = FakeIntent(
+                id="fake_payment_intent_id",
+                amount=old_amount
+            )
+            intent = get_payment_intent_from_reservation(request, reservation)
+
+        assert mock_stripe.PaymentIntent.update.called_once_with(
+            "fake_payment_intent_id",
+            updated_amount,
+        )
+        assert request.session["payment_intent_id"] == "fake_payment_intent_id"
+
+    def _build_reservation(self, show):
+        seat = Seat.objects.first()
+        tickets = {str(seat.id): "normal"}
+        return f.CreateReservation(
+            tickets=tickets, session_timeout=timezone.now(), show=show
+        )
+
+    def _build_request(self, reservation):
+        show = reservation.show
+        url = reverse(views.booking_overview, args=[show.slug])
+        request = RequestFactory().post(url)
+        middleware = SessionMiddleware()
+        middleware.process_request(request)
+        request.session.save()
+        request.session[f"show_{show.id}"] = reservation.id
+
+        return request
+
+
+class FakeIntent:
+    def __init__(self, id, amount=None):
+        self.id = id
+        self.amount = amount
 
 
 def _stripe_event():


### PR DESCRIPTION
If a user goes back from the payment page and decides to select more,
fewer, or other tickets, the sum we want to charge them will likely
change.

We should make sure to modify the payment intent when this happens, so
that we don't accidentally end up charging the wrong amount.