### PR TITLE
Fix IdempotencyError when updating reservation amounts

### DIFF
--- a/karspexet/ticket/payment.py
+++ b/karspexet/ticket/payment.py
@@ -136,6 +136,7 @@ def get_payment_intent_from_reservation(request, reservation):
         amount = reservation.get_amount()
         if payment_intent.amount != amount:
             return stripe.PaymentIntent.modify(payment_intent_id, amount=amount)
+        return payment_intent
 
     intent = stripe.PaymentIntent.create(
         amount=reservation.get_amount(),


### PR DESCRIPTION
We can't call PaymentIntent.create with different amount than what it
was originally created with, but if we already have fetched a
PaymentIntent from the API we can return it.

Fixes: https://sentry.io/organizations/martin-frost/issues/1378021899/