### PR TITLE
Fix issues in payment flow after payments are successful

### DIFF
--- a/karspexet/settings.py
+++ b/karspexet/settings.py
@@ -301,7 +301,7 @@ LOGGING = {
     "root": {"level": "INFO", "handlers": ["stdout"]},
     "formatters": {
         "default": {
-            "format": "[%(asctime)s] %(name)s: %(message)s",
+            "format": "[%(asctime)s] [%(levelname)s] %(name)s: %(message)s",
             "datefmt": "%H:%M:%S",
         },
         "django.server": {

--- a/karspexet/ticket/payment.py
+++ b/karspexet/ticket/payment.py
@@ -4,8 +4,6 @@ import logging
 
 import stripe
 from django.conf import settings
-from django.db import transaction
-from stripe.error import APIConnectionError, AuthenticationError, InvalidRequestError, RateLimitError, StripeError
 
 from karspexet.ticket.models import Account, Reservation, Ticket
 from karspexet.ticket.tasks import send_ticket_email_to_customer
@@ -14,119 +12,6 @@ from karspexet.venue.models import Seat
 logger = logging.getLogger(__name__)
 stripe_keys = settings.ENV["stripe"]
 stripe.api_key = stripe_keys['secret_key']
-
-
-class PaymentError(Exception):
-    pass
-
-
-class PaymentProcess:
-    def __init__(self, reservation, post_data, request):
-        self.reservation = reservation
-        self.data = post_data
-        self.request = request
-
-    def run(reservation, post_data, request):
-        if settings.PAYMENT_PROCESS == "fake":
-            process_class = FakePaymentProcess
-        elif settings.PAYMENT_PROCESS == "stripe":
-            process_class = StripePaymentProcess
-        else:
-            raise TypeError(
-                "Invalid payment process setting {}. "
-                "Please use either 'stripe' or 'fake'".format(settings.PAYMENT_PROCESS)
-            )
-
-        try:
-            return process_class(reservation, post_data, request).process()
-        except OSError as error:
-            logger.exception("OSError in payment process", exc_info=True, extra={
-                'request': request
-            })
-            raise PaymentError("OSError in payment process")
-
-    @transaction.atomic
-    def process(self):
-        assert self.reservation.tickets, "A reservation must have tickets to be paid for (reservation_id=%d)" % self.reservation.id
-
-        self.account = self._create_account()
-        self._create_tickets()
-
-        # Here we ensure that the ticket_price and total on the reservatino are populated.
-        # This _should_ be done in Reservation.save, but we can afford a few CPU cycles to know that this happens.
-        self.reservation.calculate_ticket_price_and_total()
-        if self.reservation.total > 0:
-            self._charge_card()
-
-        self.reservation = self._finalize_reservation()
-        self._send_mail_to_customer()
-
-        return self.reservation
-
-    def _create_account(self):
-        email = self.data['email']
-        phone = self.data['phone']
-        name = self.data['name']
-
-        return Account.objects.create(
-            name=name,
-            phone=phone,
-            email=email
-        )
-
-    def _charge_card(self):
-        raise NotImplementedError
-
-    def _create_tickets(self):
-        tickets = []
-        for seat_id, ticket_type in self.reservation.tickets.items():
-            seat = Seat.objects.get(pk=seat_id)
-            tickets.append(
-                Ticket.objects.create(
-                    price=seat.price_for_type(ticket_type),
-                    ticket_type=ticket_type,
-                    show=self.reservation.show,
-                    seat=seat,
-                    account=self.account
-                )
-            )
-
-        return tickets
-
-    def _finalize_reservation(self):
-        self.reservation.finalized = True
-        self.reservation.save()
-
-        return self.reservation
-
-    def _send_mail_to_customer(self):
-        return send_ticket_email_to_customer(self.reservation, self.account.email, self.account.name)
-
-
-class FakePaymentProcess(PaymentProcess):
-    def _charge_card(self):
-        if self.data['payment_success'] == 'true':
-            return True
-        else:
-            raise PaymentError("NO TICKETS FOR YOU")
-
-
-class StripePaymentProcess(PaymentProcess):
-    def _charge_card(self):
-        assert self.reservation.total > 0, "We cannot charge a reservation without a total price"
-        amount = self.reservation.total * 100  # Öre
-        stripe_token = self.data['stripeToken']
-
-        try:
-            return stripe.Charge.create(
-                source=stripe_token,
-                amount=amount,
-                currency="sek",
-                description="Biljetter till Kårspexet"
-            )
-        except (APIConnectionError, AuthenticationError, InvalidRequestError, RateLimitError, StripeError) as error:
-            logger.error(error)
-            raise PaymentError from error
 
 
 def get_payment_intent_from_reservation(request, reservation):
@@ -166,32 +51,14 @@ def apply_voucher(request, reservation):
 def handle_stripe_webhook(event: stripe.Event):
     logger.info("Stripe Event: %r", event)
 
-    handled = False
-    payment_intent: stripe.PaymentIntent
-    if event.type == "payment_intent.created":
-        payment_intent = event.data.object
-        logger.info("PaymentIntent created: %s", payment_intent.id)
-        handled = True
-
-    elif event.type == "payment_intent.payment_failed":
-        payment_intent = event.data.object
-        logger.info("PaymentIntent failed: %s", payment_intent.id)
-        handled = True
-
-    elif event.type == "payment_intent.succeeded":
-        payment_intent = event.data.object
+    if event.type == "payment_intent.succeeded":
+        payment_intent: stripe.PaymentIntent = event.data.object
 
         reservation = Reservation.objects.get(id=payment_intent.metadata["reservation_id"])
         billing_details = payment_intent.charges.data[0].billing_details
 
         handle_successful_payment(reservation, billing_details)
         logger.info("PaymentIntent succeeded: %s", payment_intent.id)
-        handled = True
-
-    else:
-        logger.warning("Unexpected event type: %s", event.type)
-
-    return handled
 
 
 def handle_successful_payment(reservation: Reservation, billing_data: dict):

--- a/karspexet/ticket/payment.py
+++ b/karspexet/ticket/payment.py
@@ -89,10 +89,10 @@ def handle_successful_payment(reservation: Reservation, billing_data: dict):
             account=account,
         )
 
-    send_ticket_email_to_customer(reservation, account.email, account.name)
-
     reservation.finalized = True
     reservation.save()
+
+    send_ticket_email_to_customer(reservation, account.email, account.name)
 
 
 def _pick(data, fields):

--- a/karspexet/ticket/payment.py
+++ b/karspexet/ticket/payment.py
@@ -75,7 +75,9 @@ def handle_successful_payment(reservation: Reservation, billing_data: dict):
         return
 
     billing = _pick(billing_data, ["name", "phone", "email"])
-    account, _ = Account.objects.get_or_create(**billing)
+    account = Account.objects.filter(**billing).first()
+    if account is None:
+        Account.objects.create(**billing)
 
     for seat_id, ticket_type in reservation.tickets.items():
         seat = Seat.objects.get(pk=seat_id)

--- a/karspexet/ticket/tests/test_payment.py
+++ b/karspexet/ticket/tests/test_payment.py
@@ -23,11 +23,14 @@ def test_handle_successful_payment(show):
         tickets=tickets, session_timeout=timezone.now(), show=show
     )
 
-    handle_successful_payment(reservation, {
+    data = {
         "name": "Frank Hamer",
         "email": "frank@hamer.com",
         "profession": "Police Inspector, Adventurer, Author",
-    })
+    }
+    # Handle the same webhook twice to make sure we handle it idempotently
+    handle_successful_payment(reservation, data)
+    handle_successful_payment(reservation, data)
 
     reservation.refresh_from_db()
     assert reservation.finalized

--- a/karspexet/ticket/views.py
+++ b/karspexet/ticket/views.py
@@ -55,10 +55,8 @@ def stripe_webhooks(request):
     if event is None:
         return HttpResponse(status=400)
 
-    if handle_stripe_webhook(event):
-        return HttpResponse(status=200)
-
-    return HttpResponse(status=400)
+    handle_stripe_webhook(event)
+    return HttpResponse(status=200)
 
 
 def _parse_stripe_payload(body: str) -> stripe.Event:

--- a/karspexet/ticket/views.py
+++ b/karspexet/ticket/views.py
@@ -23,7 +23,7 @@ from karspexet.ticket import payment
 from karspexet.ticket.forms import CustomerEmailForm
 from karspexet.ticket.models import (AlreadyDiscountedException, InvalidVoucherException, PricingModel, Reservation,
                                      Voucher)
-from karspexet.ticket.payment import PaymentError, PaymentProcess, handle_stripe_webhook
+from karspexet.ticket.payment import handle_stripe_webhook
 from karspexet.ticket.tasks import send_ticket_email_to_customer
 from karspexet.venue.models import Seat
 


### PR DESCRIPTION
Gör diverse ändringar för att förhindra en bunt exceptions som vi ser i prod för kunder som *gjort* sitt köp.

* Gör webhook-koden idempotent, så att vi kan ta emot flera webhookar för samma reservation utan problem
* Ser till att slänga bort gamla PaymentIntent från sessionen om de inte matchar nuvarande Reservation
* Gör att vi alltid returnerar 200 OK om en webhook går igenom, även om vi inte "hanterat" den
* Mer loggning