### PR TITLE
Reenables fake payment flow to work after new Stripe integration

### DIFF
--- a/karspexet/settings.py
+++ b/karspexet/settings.py
@@ -68,20 +68,13 @@ OUR_APPS = [
     'karspexet.show',
     'karspexet.ticket',
     'karspexet.venue',
-    'cms',
-    'menus',
-    'treebeard',
-    'sekizai',
-    'filer',
-    'easy_thumbnails',
-    'mptt',
-    'djangocms_text_ckeditor',
-    'djangocms_picture',
-    'djangocms_link',
 ]
 
 INSTALLED_APPS = [
     'djangocms_admin_style',
+    'djangocms_text_ckeditor',
+    'djangocms_picture',
+    'djangocms_link',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -91,8 +84,15 @@ INSTALLED_APPS = [
     'django.contrib.sites',
     'django.contrib.postgres',
     'raven.contrib.django.raven_compat',
-    'svg',
+    'cms',
+    'menus',
+    'treebeard',
+    'sekizai',
+    'filer',
+    'easy_thumbnails',
+    'mptt',
     'django_assets',
+    'svg',
 ] + OUR_APPS
 
 MIDDLEWARE = [

--- a/karspexet/ticket/templates/_fake_payment.html
+++ b/karspexet/ticket/templates/_fake_payment.html
@@ -1,5 +1,5 @@
+<p>Vill du att din låtsasbetalning ska lyckas eller inte?</p>
 <div class="group">
-  <span>Vill du att din låtsasbetalning ska lyckas eller inte?</span>
   <label>
     <span>Ja</span>
     <input type="radio" name="payment_success" value="true">


### PR DESCRIPTION
Fixar så att en kan ta sig igenom hela betalflödet utan Stripe nycklar.