### PR TITLE
Django: Load `static` instead of `staticfiles`

### DIFF
--- a/karspexet/templates/base.html
+++ b/karspexet/templates/base.html
@@ -1,4 +1,4 @@
-{% load menu_tags cms_tags sekizai_tags staticfiles svg %}
+{% load menu_tags cms_tags sekizai_tags static svg %}
 {% load assets %}
 <!doctype html>
 <html lang="sv">

--- a/karspexet/templates/economy/discounts.html
+++ b/karspexet/templates/economy/discounts.html
@@ -1,5 +1,5 @@
 {% extends "economy/base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% block economy_content %}
 <h2>Utnyttjade presentkort</h2>
 

--- a/karspexet/templates/economy/overview.html
+++ b/karspexet/templates/economy/overview.html
@@ -1,5 +1,5 @@
 {% extends "economy/base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% block economy_content %}
 <h2>Föreställningsöversikt</h2>
 

--- a/karspexet/templates/economy/show_detail.html
+++ b/karspexet/templates/economy/show_detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% block content %}
 <h2>Föreställningsöversikt: {{show.production.name}} {{ show.short_description }} {{show.date|date:"Y-m-d H:i:s" }}</h2>
 <em>{{show.venue}}</em>

--- a/karspexet/templates/economy/vouchers.html
+++ b/karspexet/templates/economy/vouchers.html
@@ -1,5 +1,5 @@
 {% extends "economy/base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% block title %}Kårspexet - Presentkort{% endblock %}
 {% block economy_content %}
 <h2>Presentkort</h2>

--- a/karspexet/templates/menu.html
+++ b/karspexet/templates/menu.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 {% for child in children %}
     <li class="child{% if child.selected %} selected{% endif %}{% if child.ancestor %} ancestor{% endif %}{% if child.sibling %} sibling{% endif %}{% if child.descendant %} descendant{% endif %}">
         <a class="nav-link"href="{{ child.attr.redirect_url|default:child.get_absolute_url }}">{{ child.get_menu_title }}</a>

--- a/karspexet/templates/ticket/base.html
+++ b/karspexet/templates/ticket/base.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles svg %}
+{% load static svg %}
 {% block content %}
     {% if messages %}
     <section>

--- a/karspexet/templates/ticket/select_seats.html
+++ b/karspexet/templates/ticket/select_seats.html
@@ -1,5 +1,5 @@
 {% extends "ticket/base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% block title %}
   Köp biljett - Kårspexet
 {% endblock %}

--- a/karspexet/ticket/templates/reservation_detail.html
+++ b/karspexet/ticket/templates/reservation_detail.html
@@ -1,5 +1,5 @@
 {% extends "ticket/base.html" %}
-{% load staticfiles svg %}
+{% load static svg %}
 {% block ticket_content %}
 <div class="content_container ticket-detail">
   <div class="ticket-detail-header">

--- a/karspexet/ticket/templates/ticket_detail.html
+++ b/karspexet/ticket/templates/ticket_detail.html
@@ -1,4 +1,4 @@
-{% load staticfiles svg %}
+{% load static svg %}
 <html lang="sv">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />


### PR DESCRIPTION
> Changed in Django 1.10:
> In older versions, you had to use `{% load static from staticfiles %}`
> in your template to serve files from the storage defined in
> `STATICFILES_STORAGE`. This is no longer required.