### PR TITLE
Fix development postgres startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,4 @@ services:
     environment:
       POSTGRES_USER: karspexet
       POSTGRES_DB: karspexet
+      POSTGRES_HOST_AUTH_METHOD: trust


### PR DESCRIPTION
In later versions of the Postgres docker image, you either need to set
`POSTGRES_HOST_AUTH_METHOD` to `trust` explicitly or set a password.