### PR TITLE
Django: Remove deprecated SessionAuthenticationMiddleware

### DIFF
--- a/karspexet/settings.py
+++ b/karspexet/settings.py
@@ -110,7 +110,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.locale.LocaleMiddleware',


### PR DESCRIPTION
See: https://docs.djangoproject.com/en/2.0/releases/1.10/